### PR TITLE
Helm integration for gnus-recent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/gnus-recent.elc
+# backup, bytecode
+*~
+*.elc

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -1,0 +1,39 @@
+;;; gnus-recent-helm.el --- select recently read Gnus articles with helm -*- lexical-binding: t -*-
+
+;;; Commentary:
+
+;;; Avoid having to open Gnus and find the right group just to get back to
+;;; that e-mail you were reading.
+
+;;; To use, require and bind whatever keys you prefer to the
+;;; interactive functions:
+;;;
+;;; (require 'gnus-recent-helm)
+;;; (global-set-key (kbd "<f3>") #'gnus-recent-helm)
+
+;;; If you prefer `use-package', the above settings would be:
+;;;
+;;; (use-package gnus-recent-helm
+;;;   :after gnus
+;;;   :bind (("<f3>" . gnus-recent-helm)))
+
+;;; Code:
+
+(require 'gnus-recent)
+(require 'helm)
+(require 'helm-sources)
+
+(defun gnus-recent-helm ()
+  "Select a recent Gnus article to open with `helm'."
+  (interactive)
+  (helm :sources `(((name . "Gnus recent articles")
+                    (candidates . ,(mapcar (lambda (item)
+                                             (cons (car item) item))
+                                           gnus-recent--articles-list)) 
+                    (action . (("Insert Org link" . gnus-recent-insert-org-link)
+                               ("Open article"    . gnus-recent--open-article)
+                               ("Forget article"  . gnus-recent-forget)))))
+        :buffer "*helm gnus recent*"))
+
+(provide 'gnus-recent-helm)
+;;; gnus-recent-helm.el ends here

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -1,4 +1,23 @@
 ;;; gnus-recent-helm.el --- select recently read Gnus articles with helm -*- lexical-binding: t -*-
+;;
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "25.3.2") (gnus-recent "0.2.0") (helm))
+;; Keywords: convenience, mail
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
@@ -35,4 +54,10 @@
         :buffer "*helm gnus recent*"))
 
 (provide 'gnus-recent-helm)
+
+;; Local Variables:
+;; coding: utf-8
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; gnus-recent-helm.el ends here

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -21,7 +21,6 @@
 
 (require 'gnus-recent)
 (require 'helm)
-(require 'helm-sources)
 
 (defun gnus-recent-helm ()
   "Select a recent Gnus article to open with `helm'."
@@ -30,8 +29,8 @@
                     (candidates . ,(mapcar (lambda (item)
                                              (cons (car item) item))
                                            gnus-recent--articles-list)) 
-                    (action . (("Insert Org link" . gnus-recent-insert-org-link)
-                               ("Open article"    . gnus-recent--open-article)
+                    (action . (("Open article"    . gnus-recent--open-article)
+                               ("Insert Org link" . gnus-recent-insert-org-link)
                                ("Forget article"  . gnus-recent-forget)))))
         :buffer "*helm gnus recent*"))
 

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -48,9 +48,10 @@
                     (candidates . ,(mapcar (lambda (item)
                                              (cons (car item) item))
                                            gnus-recent--articles-list)) 
-                    (action . (("Open article"    . gnus-recent--open-article)
-                               ("Insert Org link" . gnus-recent-insert-org-link)
-                               ("Forget article"  . gnus-recent-forget)))))
+                    (action . (("Open article"               . gnus-recent--open-article)
+                               ("Copy org link to kill ring" . gnus-recent-kill-new-org-link)
+                               ("Insert org link"            . gnus-recent-insert-org-link)
+                               ("Remove article"             . gnus-recent-forget)))))
         :buffer "*helm gnus recent*"))
 
 (provide 'gnus-recent-helm)

--- a/gnus-recent-ivy.el
+++ b/gnus-recent-ivy.el
@@ -56,6 +56,7 @@
 (eval-after-load 'ivy
   '(ivy-add-actions #'gnus-recent-ivy
                     '(("l" gnus-recent-insert-org-link "insert org link")
+                      ("c" gnus-recent-kill-new-org-link "copy org link")
                       ("k" gnus-recent-forget "forget"))))
 
 

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -139,19 +139,27 @@ Warn if RECENT can't be deconstructed as expected."
          (gnus-summary-read-group group 1) ; have to show at least one old one
          (gnus-summary-refer-article message-id))))))
 
-(defun gnus-recent-insert-org-link (recent)
-  "Insert an `org-mode' link to RECENT Gnus article."
+(defun gnus-recent--create-org-link (recent)
+  "Return an `org-mode' link to RECENT Gnus article"
   (gnus-recent--action
    recent
    (lambda (message-id group)
-     (insert (format "[[gnus:%s#%s][Email from %s]]"
-                     group
-                     (replace-regexp-in-string "^<\\|>$"
-                                               ""
-                                               message-id)
-                     (replace-regexp-in-string "[][]"
-                                               ""
-                                               (substring (car recent) 0 48)))))))
+      (format "[[gnus:%s#%s][Email from %s]]"
+                group
+                (replace-regexp-in-string "^<\\|>$"
+                                          ""
+                                          message-id)
+                (replace-regexp-in-string "[][]"
+                                          ""
+                                          (substring (car recent) 0 48))))))
+
+(defun gnus-recent-kill-new-org-link (recent)
+  "Add to the kill-ring an `org-mode' link to RECENT Gnus article"
+  (kill-new (gnus-recent--create-org-link recent)))
+
+(defun gnus-recent-insert-org-link (recent)
+  "Insert an `org-mode' link to RECENT Gnus article"
+  (insert (gnus-recent--create-org-link recent)))
 
 (defun gnus-recent-forget (recent)
   "Remove RECENT Gnus article from `gnus-recent--articles-list'."


### PR DESCRIPTION
Added the GPL.
the .gitignore is being carried over. too.
Your commentary with the word ivy replaced by helm.