### PR TITLE
use gnus-summary-article-header for article data; org-gnus-follow-link to open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 
 # misc
 helm-tut.el
-
+scratch.txt

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -51,7 +51,8 @@
                     (action . (("Open article"               . gnus-recent--open-article)
                                ("Copy org link to kill ring" . gnus-recent-kill-new-org-link)
                                ("Insert org link"            . gnus-recent-insert-org-link)
-                               ("Remove article"             . gnus-recent-helm-forget)))))
+                               ("Remove article"             . gnus-recent-helm-forget)
+                               ("Clear all"                  . gnus-recent-forget-all)))))
         :buffer "*helm gnus recent*"))
 
 (defun gnus-recent-helm-forget (_recent)
@@ -60,7 +61,9 @@ Helm allows for marked articles or current selection. See
 function `helm-marked-candidates'. Argument _recent is not used."
   (let ((cand (helm-marked-candidates)))
     (dolist (article cand)
-      (cl-delete article gnus-recent--articles-list :test 'equal :count 1))
+      (if (equal article (car gnus-recent--articles-list))
+          (pop gnus-recent--articles-list)
+        (cl-delete article gnus-recent--articles-list :test 'equal :count 1)))
     (message "Removed %d article(s) from gnus-recent" (length cand))))
 
 (provide 'gnus-recent-helm)

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -61,9 +61,9 @@ Helm allows for marked articles or current selection. See
 function `helm-marked-candidates'. Argument _recent is not used."
   (let ((cand (helm-marked-candidates)))
     (dolist (article cand)
-      (if (equal article (car gnus-recent--articles-list))
-          (pop gnus-recent--articles-list)
-        (cl-delete article gnus-recent--articles-list :test 'equal :count 1)))
+      (setq gnus-recent--articles-list
+            (cl-delete  article gnus-recent--articles-list
+                        :test 'equal :count 1)))
     (message "Removed %d article(s) from gnus-recent" (length cand))))
 
 (provide 'gnus-recent-helm)

--- a/gnus-recent-ivy.el
+++ b/gnus-recent-ivy.el
@@ -57,7 +57,8 @@
   '(ivy-add-actions #'gnus-recent-ivy
                     '(("l" gnus-recent-insert-org-link "insert org link")
                       ("c" gnus-recent-kill-new-org-link "copy org link")
-                      ("k" gnus-recent-forget "forget"))))
+                      ("k" gnus-recent-forget "forget")
+                      ("a" gnus-recent-forget-all "clear all"))))
 
 
 (provide 'gnus-recent-ivy)

--- a/gnus-recent-ivy.el
+++ b/gnus-recent-ivy.el
@@ -58,7 +58,7 @@
                     '(("l" gnus-recent-insert-org-link "insert org link")
                       ("c" gnus-recent-kill-new-org-link "copy org link")
                       ("k" gnus-recent-forget "forget")
-                      ("a" gnus-recent-forget-all "clear all"))))
+                      ("K" gnus-recent-forget-all "forget all"))))
 
 
 (provide 'gnus-recent-ivy)

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -46,6 +46,7 @@
 ;;; Code:
 
 (require 'gnus-sum)
+(require 'dash)
 
 (defvar gnus-recent--articles-list nil
   "The list of articles read in this Emacs session.")

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -64,28 +64,29 @@
   "Face used for dates in the recent article list."
   :group 'gnus-recent)
 
+(defun gnus-recent-date-format (date)
+  "Convert the DATE to 'YYYY-MM-D HH:MM:SS a' format."
+  (condition-case ()
+      (format-time-string "%F %T %a" (gnus-date-get-time date))
+    (error "")))
+
 (defun gnus-recent--get-article-data ()
-  "Get the article data used for gnus-recent."
-  (unless gnus-recent--showing-recent
-    (set-buffer gnus-summary-buffer)
-    (let ((article-number
-           ;; based on gnus-summary-article-header (a macro which fails here):
-           (gnus-data-header (gnus-data-find
-                              (progn
-                                (gnus-summary-skip-intangible)
-                                (or (get-text-property (point) 'gnus-number)
-                                    (gnus-summary-last-subject)))))))
-      (list
-       (format "%s: %s \t%s"
-               (propertize
-                (replace-regexp-in-string "\\([^\<]*\\) <\\(.*\\)>" "\\1"
-                                          (replace-regexp-in-string "\"\\([^\"]*\\)\" <\\(.*\\)>" "\\1"
-                                                                    (mail-header-from article-number)))
-                'face 'bold)
-               (mail-header-subject article-number)
-               (propertize (mail-header-date article-number) 'face 'gnus-recent-date-face))
-       (mail-header-id article-number)
-       gnus-newsgroup-name))))
+    "Get the article data used for `gnus-recent' based on `gnus-summary-article-header'."
+    (unless gnus-recent--showing-recent
+      (let* ((article-number (gnus-summary-article-number))
+             (article-header (gnus-summary-article-header article-number)))
+        (list
+         (format "%s: %s \t%s"
+                 (propertize
+                  (replace-regexp-in-string "\\([^\<]*\\) <\\(.*\\)>" "\\1"
+                                            (replace-regexp-in-string "\"\\([^\"]*\\)\" <\\(.*\\)>" "\\1"
+                                                                      (mail-header-from article-header)))
+                  'face 'bold)
+                 (mail-header-subject article-header)
+                 (propertize (gnus-recent-date-format (mail-header-date article-header))
+                             'face 'gnus-recent-date-face))
+         (mail-header-id article-header)
+         gnus-newsgroup-name))))
 
 (defun gnus-recent--track-article ()
   "Store this article in the recent article list.
@@ -105,7 +106,7 @@ moved article was already tracked.  For use by
 `gnus-summary-article-move-hook'."
   (when (eq action 'move)
     (let ((article-data (gnus-recent--get-article-data)))
-      (cl-nsubstitute (list (first article-data) (second article-data) to-group) 
+      (cl-nsubstitute (list (first article-data) (second article-data) to-group)
                       article-data
                       gnus-recent--articles-list
                       :test 'equal :count 1))))
@@ -148,7 +149,7 @@ article list is the article we're currently looking at."
            (gnus-summary-refer-article message-id)))))))
 
 (defun gnus-recent--action (recent func)
-  "Find message-id and group arguments from RECENT, call FUNC on them.
+  "Find `message-id' and group arguments from RECENT, call FUNC on them.
 Warn if RECENT can't be deconstructed as expected."
   (pcase recent
     (`(,_ . (,message-id ,group . ,_))
@@ -157,16 +158,12 @@ Warn if RECENT can't be deconstructed as expected."
      (message "Couldn't parse recent message: %S" recent))))
 
 (defun gnus-recent--open-article (recent)
-  "Open RECENT gnus article."
+  "Open RECENT gnus article using `org-gnus'."
   (gnus-recent--action
    recent
    (lambda (message-id group)
-     (let* ((gnus-recent--showing-recent t))
-       (if (and (equal (current-buffer) gnus-summary-buffer)
-                (equal message-id (mail-header-id (gnus-summary-article-header))))
-           (call-interactively 'gnus-recent-goto-previous)
-         (gnus-summary-read-group group 1) ; have to show at least one old one
-         (gnus-summary-refer-article message-id))))))
+     (let ((gnus-recent--showing-recent t))
+       (org-gnus-follow-link group message-id)))))
 
 (defun gnus-recent--create-org-link (recent)
   "Return an `org-mode' link to RECENT Gnus article."
@@ -196,6 +193,11 @@ Warn if RECENT can't be deconstructed as expected."
   (cl-delete recent gnus-recent--articles-list :test 'equal :count 1)
     (message "Removed %s from gnus-recent articles" (car recent)))
 
+(defun gnus-recent-forget-all (&rest _recent)
+  "Clear the gnus-recent articles list."
+  (interactive)
+  (setq gnus-recent--articles-list nil)
+  (message "Cleared all gnus-recent article entries"))
 
 (provide 'gnus-recent)
 ;;; gnus-recent.el ends here

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -46,7 +46,6 @@
 ;;; Code:
 
 (require 'gnus-sum)
-(require 'dash)
 
 (defvar gnus-recent--articles-list nil
   "The list of articles read in this Emacs session.")


### PR DESCRIPTION

* use gnus-summary-article-header for getting article data

* open gnus-recent articles with org-gnus-follow-link

gnus-recent--article-open now uses the function org-gnus-follow-link, which
simplifies gnus-recent--open-article and is more robust.
Adds an org-gnus dependency.

* ISO date string in titles

a ISO format similar to the org-mode
date format. It is significantly more compact than the previous US/English style
date format and also can be used for sorting.

*  new functions:
    - **gnus-recent-date-format**
    - **gnus-recent-forget-all** : removes all entries from the
    gnus-recent--article-list. The user can apply it to start over. Added as an
    option to the ivy, helm interfaces.
