### PR TITLE
Tracking of expiring articles 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 
 # misc
 helm-tut.el
-
+scratch.txt

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -51,7 +51,8 @@
                     (action . (("Open article"               . gnus-recent--open-article)
                                ("Copy org link to kill ring" . gnus-recent-kill-new-org-link)
                                ("Insert org link"            . gnus-recent-insert-org-link)
-                               ("Remove article"             . gnus-recent-helm-forget)))))
+                               ("Remove article"             . gnus-recent-helm-forget)
+                               ("Clear all"                  . gnus-recent-forget-all)))))
         :buffer "*helm gnus recent*"))
 
 (defun gnus-recent-helm-forget (_recent)
@@ -60,7 +61,9 @@ Helm allows for marked articles or current selection. See
 function `helm-marked-candidates'. Argument _recent is not used."
   (let ((cand (helm-marked-candidates)))
     (dolist (article cand)
-      (cl-delete article gnus-recent--articles-list :test 'equal :count 1))
+      (if (equal article (car gnus-recent--articles-list))
+          (pop gnus-recent--articles-list)
+        (cl-delete article gnus-recent--articles-list :test 'equal :count 1)))
     (message "Removed %d article(s) from gnus-recent" (length cand))))
 
 (provide 'gnus-recent-helm)

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -61,9 +61,7 @@ Helm allows for marked articles or current selection. See
 function `helm-marked-candidates'. Argument _recent is not used."
   (let ((cand (helm-marked-candidates)))
     (dolist (article cand)
-      (setq gnus-recent--articles-list
-            (cl-delete  article gnus-recent--articles-list
-                        :test 'equal :count 1)))
+      (gnus-recent-forget article))
     (message "Removed %d article(s) from gnus-recent" (length cand))))
 
 (provide 'gnus-recent-helm)

--- a/gnus-recent-helm.el
+++ b/gnus-recent-helm.el
@@ -61,9 +61,9 @@ Helm allows for marked articles or current selection. See
 function `helm-marked-candidates'. Argument _recent is not used."
   (let ((cand (helm-marked-candidates)))
     (dolist (article cand)
-      (if (equal article (car gnus-recent--articles-list))
-          (pop gnus-recent--articles-list)
-        (cl-delete article gnus-recent--articles-list :test 'equal :count 1)))
+      (setq gnus-recent--articles-list
+            (cl-delete  article gnus-recent--articles-list
+                        :test 'equal :count 1)))
     (message "Removed %d article(s) from gnus-recent" (length cand))))
 
 (provide 'gnus-recent-helm)

--- a/gnus-recent-ivy.el
+++ b/gnus-recent-ivy.el
@@ -57,7 +57,8 @@
   '(ivy-add-actions #'gnus-recent-ivy
                     '(("l" gnus-recent-insert-org-link "insert org link")
                       ("c" gnus-recent-kill-new-org-link "copy org link")
-                      ("k" gnus-recent-forget "forget"))))
+                      ("k" gnus-recent-forget "forget")
+                      ("a" gnus-recent-forget-all "clear all"))))
 
 
 (provide 'gnus-recent-ivy)

--- a/gnus-recent-ivy.el
+++ b/gnus-recent-ivy.el
@@ -58,7 +58,7 @@
                     '(("l" gnus-recent-insert-org-link "insert org link")
                       ("c" gnus-recent-kill-new-org-link "copy org link")
                       ("k" gnus-recent-forget "forget")
-                      ("a" gnus-recent-forget-all "clear all"))))
+                      ("K" gnus-recent-forget-all "forget all"))))
 
 
 (provide 'gnus-recent-ivy)

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -46,6 +46,7 @@
 ;;; Code:
 
 (require 'gnus-sum)
+(require 'dash)
 
 (defvar gnus-recent--articles-list nil
   "The list of articles read in this Emacs session.")

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -64,28 +64,29 @@
   "Face used for dates in the recent article list."
   :group 'gnus-recent)
 
+(defun gnus-recent-date-format (date)
+  "Convert the DATE to 'YYYY-MM-D HH:MM:SS a' format."
+  (condition-case ()
+      (format-time-string "%F %T %a" (gnus-date-get-time date))
+    (error "")))
+
 (defun gnus-recent--get-article-data ()
-  "Get the article data used for gnus-recent."
-  (unless gnus-recent--showing-recent
-    (set-buffer gnus-summary-buffer)
-    (let ((article-number
-           ;; based on gnus-summary-article-header (a macro which fails here):
-           (gnus-data-header (gnus-data-find
-                              (progn
-                                (gnus-summary-skip-intangible)
-                                (or (get-text-property (point) 'gnus-number)
-                                    (gnus-summary-last-subject)))))))
-      (list
-       (format "%s: %s \t%s"
-               (propertize
-                (replace-regexp-in-string "\\([^\<]*\\) <\\(.*\\)>" "\\1"
-                                          (replace-regexp-in-string "\"\\([^\"]*\\)\" <\\(.*\\)>" "\\1"
-                                                                    (mail-header-from article-number)))
-                'face 'bold)
-               (mail-header-subject article-number)
-               (propertize (mail-header-date article-number) 'face 'gnus-recent-date-face))
-       (mail-header-id article-number)
-       gnus-newsgroup-name))))
+    "Get the article data used for `gnus-recent' based on `gnus-summary-article-header'."
+    (unless gnus-recent--showing-recent
+      (let* ((article-number (gnus-summary-article-number))
+             (article-header (gnus-summary-article-header article-number)))
+        (list
+         (format "%s: %s \t%s"
+                 (propertize
+                  (replace-regexp-in-string "\\([^\<]*\\) <\\(.*\\)>" "\\1"
+                                            (replace-regexp-in-string "\"\\([^\"]*\\)\" <\\(.*\\)>" "\\1"
+                                                                      (mail-header-from article-header)))
+                  'face 'bold)
+                 (mail-header-subject article-header)
+                 (propertize (gnus-recent-date-format (mail-header-date article-header))
+                             'face 'gnus-recent-date-face))
+         (mail-header-id article-header)
+         gnus-newsgroup-name))))
 
 (defun gnus-recent--track-article ()
   "Store this article in the recent article list.
@@ -105,7 +106,7 @@ moved article was already tracked.  For use by
 `gnus-summary-article-move-hook'."
   (when (eq action 'move)
     (let ((article-data (gnus-recent--get-article-data)))
-      (cl-nsubstitute (list (first article-data) (second article-data) to-group) 
+      (cl-nsubstitute (list (first article-data) (second article-data) to-group)
                       article-data
                       gnus-recent--articles-list
                       :test 'equal :count 1))))
@@ -148,7 +149,7 @@ article list is the article we're currently looking at."
            (gnus-summary-refer-article message-id)))))))
 
 (defun gnus-recent--action (recent func)
-  "Find message-id and group arguments from RECENT, call FUNC on them.
+  "Find `message-id' and group arguments from RECENT, call FUNC on them.
 Warn if RECENT can't be deconstructed as expected."
   (pcase recent
     (`(,_ . (,message-id ,group . ,_))
@@ -157,16 +158,12 @@ Warn if RECENT can't be deconstructed as expected."
      (message "Couldn't parse recent message: %S" recent))))
 
 (defun gnus-recent--open-article (recent)
-  "Open RECENT gnus article."
+  "Open RECENT gnus article using `org-gnus'."
   (gnus-recent--action
    recent
    (lambda (message-id group)
-     (let* ((gnus-recent--showing-recent t))
-       (if (and (equal (current-buffer) gnus-summary-buffer)
-                (equal message-id (mail-header-id (gnus-summary-article-header))))
-           (call-interactively 'gnus-recent-goto-previous)
-         (gnus-summary-read-group group 1) ; have to show at least one old one
-         (gnus-summary-refer-article message-id))))))
+     (let ((gnus-recent--showing-recent t))
+       (org-gnus-follow-link group message-id)))))
 
 (defun gnus-recent--create-org-link (recent)
   "Return an `org-mode' link to RECENT Gnus article."
@@ -196,6 +193,11 @@ Warn if RECENT can't be deconstructed as expected."
   (cl-delete recent gnus-recent--articles-list :test 'equal :count 1)
     (message "Removed %s from gnus-recent articles" (car recent)))
 
+(defun gnus-recent-forget-all (&rest _recent)
+  "Clear the gnus-recent articles list."
+  (interactive)
+  (setq gnus-recent--articles-list nil)
+  (message "Cleared all gnus-recent article entries"))
 
 (provide 'gnus-recent)
 ;;; gnus-recent.el ends here

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -46,6 +46,7 @@
 ;;; Code:
 
 (require 'gnus-sum)
+(require 'org-gnus)
 
 (defvar gnus-recent--articles-list nil
   "The list of articles read in this Emacs session.")
@@ -96,33 +97,42 @@ For tracking of Backend moves (B-m) see `gnus-recent--track-move-article'."
       (add-to-list 'gnus-recent--articles-list article-data)))
   (setq gnus-recent--showing-recent nil))
 
-(add-hook 'gnus-article-prepare-hook 'gnus-recent--track-article)
-
 (defun gnus-recent--track-move-article (action _article _from-group to-group _select-method)
   "Track backend move (B-m) of articles.
 When ACTION is 'move, will change the group to TO-GROUP for the
 article data in `gnus-recent--articles-list', but only if the
-moved article was already tracked.  For use by
+moved article was already tracked. For use by
 `gnus-summary-article-move-hook'."
   (when (eq action 'move)
-    (let ((article-data (gnus-recent--get-article-data)))
-      (cl-nsubstitute (list (first article-data) (second article-data) to-group)
-                      article-data
-                      gnus-recent--articles-list
-                      :test 'equal :count 1))))
+    (gnus-recent-update (gnus-recent--get-article-data) to-group)))
 
-(add-hook 'gnus-summary-article-move-hook 'gnus-recent--track-move-article)
-
-(defun gnus-recent--track-delete-article (action ghead group &rest rest)
-  "Track interactive user deletion of articles and remove the
-article data in `gnus-recent--articles-list'. This function is
-applied by the abnormal hook `gnus-summary-article-delete-hook'."
+(defun gnus-recent--track-delete-article (action _article _from-group &rest _rest)
+  "Track interactive user deletion of articles.
+Remove the article data in `gnus-recent--articles-list'. ACTION
+should be 'delete.
+For use by `gnus-summary-article-delete-hook'."
   (when (eq action 'delete)
-    (cl-delete (gnus-recent--get-article-data)
-               gnus-recent--articles-list
-               :test 'equal :count 1)))
+    (gnus-recent-forget (gnus-recent--get-article-data))))
 
+(defun gnus-recent--track-expire-article (action _article _from-group to-group _select-method)
+  "Track when articles expire.
+Handle the article data in `gnus-recent--articles-list',
+according to the expiry ACTION. TO-GROUP should have the value of
+the expiry-target group if set.
+For use by `gnus-summary-article-expire-hook'."
+  (when (eq action 'delete)
+    (let ((article-data (gnus-recent--get-article-data)))
+      (when (member article-data gnus-recent--articles-list)
+          (if to-group                  ; article moves to the expiry-target group
+              (gnus-recent-update article-data to-group)
+            (gnus-recent-forget article-data)))))) ; article is deleted
+
+;; Activate the hooks  (should be named -functions)
+;; Note: except for the 1st, the other hooks run using run-hook-with-args
+(add-hook 'gnus-article-prepare-hook        'gnus-recent--track-article)
+(add-hook 'gnus-summary-article-move-hook   'gnus-recent--track-move-article)
 (add-hook 'gnus-summary-article-delete-hook 'gnus-recent--track-delete-article)
+(add-hook 'gnus-summary-article-expire-hook 'gnus-recent--track-expire-article)
 
 (defmacro gnus-recent--shift (lst)
   "Put the first element of LST last, then return that element."
@@ -188,10 +198,20 @@ Warn if RECENT can't be deconstructed as expected."
   "Insert an `org-mode' link to RECENT Gnus article."
   (insert (gnus-recent--create-org-link recent)))
 
-(defun gnus-recent-forget (recent)
+(defun gnus-recent-update (recent to-group)
+  "Update RECENT Gnus article in `gnus-recent--articles-list'.
+The Gnus article has moved to group TO-GROUP."
+  (cl-nsubstitute (list (first recent) (second recent) to-group)
+                  recent
+                  gnus-recent--articles-list
+                  :test 'equal :count 1))
+
+(defun gnus-recent-forget (recent &optional print-msg)
   "Remove RECENT Gnus article from `gnus-recent--articles-list'."
-  (cl-delete recent gnus-recent--articles-list :test 'equal :count 1)
-    (message "Removed %s from gnus-recent articles" (car recent)))
+  (setq gnus-recent--articles-list 
+        (cl-delete recent gnus-recent--articles-list :test 'equal :count 1))
+  (if print-msg
+      (message "Removed %s from gnus-recent articles" (car recent))))
 
 (defun gnus-recent-forget-all (&rest _recent)
   "Clear the gnus-recent articles list."

--- a/gnus-recent.el
+++ b/gnus-recent.el
@@ -46,7 +46,6 @@
 ;;; Code:
 
 (require 'gnus-sum)
-(require 'dash)
 
 (defvar gnus-recent--articles-list nil
   "The list of articles read in this Emacs session.")


### PR DESCRIPTION
* Expiring tracking

With the addition of expiring tracking, all 3 (move, delete, expire) tracking functions gnus-recent--track-*-article are implemented and added to the respective gnus-summary-article-*-hook(s) . The consistency and reliability of finding the gnus-recent articles should now be considerably better.

* Editing of gnus-recent list

Direct changes to the gnus-recent--articles-list now take place only by the gnu-recent-{update,forget} functions.

* require gnus-org

